### PR TITLE
Render AI chat responses as formatted markdown

### DIFF
--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -1,11 +1,56 @@
 "use client";
 
+import ReactMarkdown from "react-markdown";
 import { ActionCard } from "./ActionCard";
 import type { ChatMessage } from "@/types/chat";
 
 interface ChatMessageProps {
   message: ChatMessage;
 }
+
+// Markdown component map: maps markdown tokens to styled HTML elements
+const markdownComponents: React.ComponentProps<typeof ReactMarkdown>["components"] = {
+  // H1 → large heading
+  h1: ({ children }) => (
+    <h1 className="text-sm font-bold mt-3 mb-1 leading-snug">{children}</h1>
+  ),
+  // H2 → subheading
+  h2: ({ children }) => (
+    <h2 className="text-xs font-bold mt-2 mb-1 leading-snug tracking-wide uppercase opacity-80">{children}</h2>
+  ),
+  // H3 → section label
+  h3: ({ children }) => (
+    <h3 className="text-xs font-semibold mt-2 mb-0.5 leading-snug">{children}</h3>
+  ),
+  // Paragraphs with breathing room between them
+  p: ({ children }) => (
+    <p className="leading-relaxed mb-2 last:mb-0">{children}</p>
+  ),
+  // Bold text → actual bold
+  strong: ({ children }) => (
+    <strong className="font-bold">{children}</strong>
+  ),
+  // Horizontal rule → visible divider line
+  hr: () => (
+    <hr className="my-2 border-t border-current opacity-20" />
+  ),
+  // Unordered list
+  ul: ({ children }) => (
+    <ul className="list-disc list-inside space-y-0.5 mb-2 pl-1">{children}</ul>
+  ),
+  // Ordered list
+  ol: ({ children }) => (
+    <ol className="list-decimal list-inside space-y-0.5 mb-2 pl-1">{children}</ol>
+  ),
+  // List items
+  li: ({ children }) => (
+    <li className="leading-relaxed">{children}</li>
+  ),
+  // Inline code
+  code: ({ children }) => (
+    <code className="bg-black/20 rounded px-1 py-0.5 text-[10px] font-mono">{children}</code>
+  ),
+};
 
 export function ChatMessageComponent({ message }: ChatMessageProps) {
   const isAssistant = message.role === "assistant";
@@ -22,12 +67,23 @@ export function ChatMessageComponent({ message }: ChatMessageProps) {
             : "bg-primary text-primary-foreground"
         }`}
       >
-        <p className="whitespace-pre-wrap leading-relaxed">
-          {message.content}
-          {message.status === "streaming" && (
-            <span className="inline-block w-1.5 h-3.5 bg-current ml-0.5 animate-pulse align-middle" />
-          )}
-        </p>
+        {isAssistant ? (
+          <div className="leading-relaxed">
+            <ReactMarkdown components={markdownComponents}>
+              {message.content}
+            </ReactMarkdown>
+            {message.status === "streaming" && (
+              <span className="inline-block w-1.5 h-3.5 bg-current ml-0.5 animate-pulse align-middle" />
+            )}
+          </div>
+        ) : (
+          <p className="whitespace-pre-wrap leading-relaxed">
+            {message.content}
+            {message.status === "streaming" && (
+              <span className="inline-block w-1.5 h-3.5 bg-current ml-0.5 animate-pulse align-middle" />
+            )}
+          </p>
+        )}
 
         {message.suggestedActions && message.suggestedActions.length > 0 && (
           <div className="mt-2 space-y-1">

--- a/src/lib/chat/context-builder.ts
+++ b/src/lib/chat/context-builder.ts
@@ -41,6 +41,19 @@ When you recommend plan changes:
 - For remove_course: only suggest courses ALREADY in the plan
 - If no plan changes are needed, omit the ACTIONS_JSON block entirely
 
+RESPONSE FORMATTING RULES:
+Your responses are rendered as markdown. Follow these rules exactly:
+- Use # for a top-level heading that introduces the entire response topic (use sparingly, one per response max)
+- Use ## for subheadings that introduce a new section within your response
+- Use ### for a finer section label or category within a ## section
+- Use **text** to bold key terms, course IDs, requirement names, or critical callouts — not for decoration
+- Use --- on its own line to insert a visible horizontal divider between major sections
+- Use bullet lists (- item) for enumerations, options, or multi-item explanations
+- Use numbered lists (1. item) only when order or sequence matters
+- Always leave a blank line between paragraphs, between a heading and its content, and before/after a --- divider
+- Keep responses concise — avoid walls of text; prefer short paragraphs and lists
+- Never output raw markdown syntax as literal characters (e.g. do not write \*\*bold\*\* — just use **bold**)
+
 ACTIONS_JSON format (append at the very end of your response if suggesting changes):
 ACTIONS_JSON: [
   {"type":"add_course","courseId":"LGST6110","location":"Y1S_Q3","reason":"Satisfies LGST core requirement"},


### PR DESCRIPTION
## Summary

- Add `react-markdown` with a custom component map to `ChatMessage.tsx`, rendering headings (`h1`/`h2`/`h3`), bold text, horizontal dividers (`hr`), bullet/ordered lists, and inline code as styled HTML elements instead of raw markdown syntax
- Add `RESPONSE FORMATTING RULES` to the system prompt in `context-builder.ts`, instructing the AI to use structured markdown (headings, bold callouts, `---` dividers, lists) for human-readable, visually formatted responses
- User messages continue to render as plain `whitespace-pre-wrap` text — markdown rendering is assistant-only

## Test plan

- [ ] Start a dev server and open the chat panel
- [ ] Send a question that produces a multi-section response (e.g. "What courses do I need for my major?")
- [ ] Confirm headings render as larger/bolder text, not raw `#` characters
- [ ] Confirm `**bold**` renders as actual bold, not asterisks
- [ ] Confirm `---` renders as a visible divider line
- [ ] Confirm bullet lists render with disc markers
- [ ] Confirm user messages are unaffected (plain text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)