### PR TITLE
Add light/dark mode toggle with Anthropic Claude color palette

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,29 +4,29 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
-  --color-background: #09090b;
-  --color-foreground: #fafafa;
-  --color-card: #09090b;
-  --color-card-foreground: #fafafa;
-  --color-popover: #09090b;
-  --color-popover-foreground: #fafafa;
-  --color-primary: #fafafa;
-  --color-primary-foreground: #18181b;
-  --color-secondary: #27272a;
-  --color-secondary-foreground: #fafafa;
-  --color-muted: #27272a;
-  --color-muted-foreground: #a1a1aa;
-  --color-accent: #27272a;
-  --color-accent-foreground: #fafafa;
-  --color-destructive: #7f1d1d;
-  --color-destructive-foreground: #fafafa;
-  --color-border: #27272a;
-  --color-input: #27272a;
-  --color-ring: #d4d4d8;
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
   --color-warning: #f59e0b;
-  --color-warning-foreground: #18181b;
-  --color-success: #22c55e;
-  --color-success-foreground: #18181b;
+  --color-warning-foreground: #141413;
+  --color-success: #788c5d;
+  --color-success-foreground: #ffffff;
   --radius-sm: 0.25rem;
   --radius-md: 0.375rem;
   --radius-lg: 0.5rem;
@@ -49,82 +49,77 @@
   --radius-4xl: calc(var(--radius) + 16px);
 }
 
-body {
-  background-color: var(--color-background);
-  color: var(--color-foreground);
-}
-
-* {
-  border-color: var(--color-border);
-}
-
+/* Light mode — Anthropic Claude palette */
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.141 0.005 285.823);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.141 0.005 285.823);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.141 0.005 285.823);
-  --primary: oklch(0.21 0.006 285.885);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.967 0.001 286.375);
-  --secondary-foreground: oklch(0.21 0.006 285.885);
-  --muted: oklch(0.967 0.001 286.375);
-  --muted-foreground: oklch(0.552 0.016 285.938);
-  --accent: oklch(0.967 0.001 286.375);
-  --accent-foreground: oklch(0.21 0.006 285.885);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.92 0.004 286.32);
-  --input: oklch(0.92 0.004 286.32);
-  --ring: oklch(0.705 0.015 286.067);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.141 0.005 285.823);
-  --sidebar-primary: oklch(0.21 0.006 285.885);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.967 0.001 286.375);
-  --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
-  --sidebar-border: oklch(0.92 0.004 286.32);
-  --sidebar-ring: oklch(0.705 0.015 286.067);
+  --background: #faf9f5;
+  --foreground: #141413;
+  --card: #ffffff;
+  --card-foreground: #141413;
+  --popover: #ffffff;
+  --popover-foreground: #141413;
+  --primary: #d97757;
+  --primary-foreground: #ffffff;
+  --secondary: #6a9bcc;
+  --secondary-foreground: #ffffff;
+  --muted: #e8e6dc;
+  --muted-foreground: #6b6965;
+  --accent: #e8e6dc;
+  --accent-foreground: #141413;
+  --destructive: #c0392b;
+  --destructive-foreground: #ffffff;
+  --border: #e8e6dc;
+  --input: #e8e6dc;
+  --ring: #d97757;
+  --chart-1: #d97757;
+  --chart-2: #6a9bcc;
+  --chart-3: #788c5d;
+  --chart-4: #c0392b;
+  --chart-5: #b0aea5;
+  --sidebar: #f0ede5;
+  --sidebar-foreground: #141413;
+  --sidebar-primary: #d97757;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #e8e6dc;
+  --sidebar-accent-foreground: #141413;
+  --sidebar-border: #e8e6dc;
+  --sidebar-ring: #d97757;
 }
 
+/* Dark mode — Anthropic Claude palette */
 .dark {
-  --background: oklch(0.141 0.005 285.823);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.21 0.006 285.885);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.21 0.006 285.885);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.92 0.004 286.32);
-  --primary-foreground: oklch(0.21 0.006 285.885);
-  --secondary: oklch(0.274 0.006 286.033);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.274 0.006 286.033);
-  --muted-foreground: oklch(0.705 0.015 286.067);
-  --accent: oklch(0.274 0.006 286.033);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
+  --background: #141413;
+  --foreground: #faf9f5;
+  --card: #1e1d1c;
+  --card-foreground: #faf9f5;
+  --popover: #1e1d1c;
+  --popover-foreground: #faf9f5;
+  --primary: #d97757;
+  --primary-foreground: #ffffff;
+  --secondary: #6a9bcc;
+  --secondary-foreground: #ffffff;
+  --muted: #2a2927;
+  --muted-foreground: #8a8880;
+  --accent: #2a2927;
+  --accent-foreground: #faf9f5;
+  --destructive: #e74c3c;
+  --destructive-foreground: #ffffff;
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.552 0.016 285.938);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.21 0.006 285.885);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.274 0.006 286.033);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --ring: #d97757;
+  --chart-1: #d97757;
+  --chart-2: #6a9bcc;
+  --chart-3: #788c5d;
+  --chart-4: #e74c3c;
+  --chart-5: #8a8880;
+  --sidebar: #1e1d1c;
+  --sidebar-foreground: #faf9f5;
+  --sidebar-primary: #d97757;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #2a2927;
+  --sidebar-accent-foreground: #faf9f5;
   --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.552 0.016 285.938);
+  --sidebar-ring: #d97757;
 }
 
 @layer base {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import { Toaster } from "@/components/ui/sonner";
+import { ThemeProvider } from "@/components/providers/ThemeProvider";
 import "./globals.css";
 
 const inter = Inter({
@@ -19,10 +20,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className="dark">
+    <html lang="en" suppressHydrationWarning>
       <body className={`${inter.variable} font-sans antialiased`}>
-        {children}
-        <Toaster position="top-right" />
+        <ThemeProvider>
+          {children}
+          <Toaster position="top-right" />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useTheme } from "next-themes";
+import { Sun, Moon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { usePlanStore } from "@/stores/plan-store";
 import { useUIStore } from "@/stores/ui-store";
@@ -13,6 +15,7 @@ export function Header() {
   const rightPanelOpen = useUIStore((s) => s.rightPanelOpen);
   const rightPanelView = useUIStore((s) => s.rightPanelView);
   const setRightPanelView = useUIStore((s) => s.setRightPanelView);
+  const { theme, setTheme } = useTheme();
 
   return (
     <header className="h-14 border-b flex items-center justify-between px-4 bg-card shrink-0">
@@ -57,6 +60,18 @@ export function Header() {
           className={rightPanelOpen && rightPanelView === "chat" ? "" : "text-muted-foreground"}
         >
           Chat
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+          aria-label="Toggle theme"
+        >
+          {theme === "dark" ? (
+            <Sun className="size-4" />
+          ) : (
+            <Moon className="size-4" />
+          )}
         </Button>
         <ExportMenu />
         <Button variant="ghost" size="sm" onClick={toggleRightPanel}>

--- a/src/components/providers/ThemeProvider.tsx
+++ b/src/components/providers/ThemeProvider.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <NextThemesProvider attribute="class" defaultTheme="dark" enableSystem={false}>
+      {children}
+    </NextThemesProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a toggleable light/dark mode via `next-themes` (Sun/Moon button in Header)
- Replaces the zinc-based hardcoded dark palette with the Anthropic Claude brand palette across both themes
- Light mode: warm cream background (`#faf9f5`), orange primary accent (`#d97757`), blue secondary accent (`#6a9bcc`)
- Dark mode: near-black background (`#141413`), same orange/blue accents for consistency
- Improved light mode muted text contrast for accessibility (WCAG AA compliant: `#b0aea5` → `#6b6965`)

## Files Changed
- `src/app/globals.css` — full palette overhaul; `@theme inline` now references CSS vars for live theme switching
- `src/app/layout.tsx` — ThemeProvider integration, removed hardcoded `dark` class, added `suppressHydrationWarning`
- `src/components/layout/Header.tsx` — Sun/Moon theme toggle button using `next-themes`
- `src/components/providers/ThemeProvider.tsx` — new client wrapper around `next-themes`

## Test Plan
- [ ] App loads in dark mode by default
- [ ] Clicking Sun icon switches to light mode; Moon icon switches back to dark
- [ ] Theme preference persists on page refresh (stored in localStorage)
- [ ] Both modes use the Anthropic Claude color palette
- [ ] Muted/secondary text is legible in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)